### PR TITLE
Expand API Specification with mosquitto occurrence endpoint

### DIFF
--- a/backend/docs/api-specification.yml
+++ b/backend/docs/api-specification.yml
@@ -212,3 +212,55 @@ paths:
           description: Invalid request
         '500':
           description: Server error
+  /mosquito-occurrence:
+    get:
+      summary: Get mosquito occurrences in Austria
+      description: Fetches mosquito occurrence data from GBIF API and returns coordinates
+      responses:
+        '200':
+          description: A JSON array of mosquito occurrences
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      example: "12345-abc"
+                    latitude:
+                      type: number
+                      format: float
+                      example: 48.2082
+                    longitude:
+                      type: number
+                      format: float
+                      example: 16.3738
+                    date:
+                      type: string
+                      format: date
+                      example: "2024-03-31"
+                    source:
+                      type: string
+                      example: "GBIF"
+        '400':
+          description: Invalid request (e.g., missing or incorrect parameters)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Invalid taxon key"
+        '500':
+          description: Internal Server error (e.g., GBIF API failure)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Failed to fetch data from GBIF"


### PR DESCRIPTION
# Description
- Add /mosquito-occurrence endpoint
- Fetches mosquito occurrence data from GBIF for Austria 🇦🇹
- Returns id, latitude, longitude, date, and source
- Handles 400 (invalid request) & 500 (server error) responses