### PR TITLE
fix: add MockitoBean into backend tests

### DIFF
--- a/backend/src/test/java/at/big5health/klimaatlas/WeatherControllerTest.java
+++ b/backend/src/test/java/at/big5health/klimaatlas/WeatherControllerTest.java
@@ -11,13 +11,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -34,7 +32,7 @@ class WeatherControllerTest {
     @Autowired
     private MockMvc mockMvc; // For performing HTTP requests
 
-    @MockBean // Create a mock bean for WeatherService in the application context
+    @MockitoBean // Create a mock bean for WeatherService in the application context
     private WeatherService weatherService;
 
     @Autowired


### PR DESCRIPTION
# Description
This pull request updates the backend test suite to address a deprecation warning related to the use of @MockBean.
The annotation @MockBean from org.springframework.boot.test.mock.mockito has been deprecated and is scheduled for removal in Spring Boot 4.0.0.
To ensure forward compatibility and prevent potential issues during future upgrades, this PR replaces @MockBean with @MockitoBean from the Spring Framework.

## Key Changes
+ Replaced all usages of @MockBean with @MockitoBean from org.springframework.test.context.bean.override.mockito.MockitoBean
+ Updated relevant import statements to reflect the new annotation
+ Verified all affected test classes still compile and run successfully
+ Ensured compatibility with existing Spring TestContext framework

## Motivation
By proactively migrating to @MockitoBean, we ensure compatibility with Spring Boot 4.x and avoid runtime errors or broken tests due to removed functionality in future versions.