### PR TITLE
feat: add caching mechanism

### DIFF
--- a/backend/src/main/java/at/big5health/klimaatlas/CacheConfig.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/CacheConfig.java
@@ -20,9 +20,6 @@ public class CacheConfig {
         ConcurrentMapCacheManager manager = new ConcurrentMapCacheManager();
         manager.setAllowNullValues(false);
 
-        // Cache-Regionen definieren:
-        // - weatherCache: Für individuelle Wetterdatenabfragen
-        // - temperatureGrid: Für das Temperatur-Raster pro Bundesland
         manager.setCacheNames(Arrays.asList("weatherCache", "temperatureGrid"));
 
         return manager;
@@ -31,10 +28,9 @@ public class CacheConfig {
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(5); // Anzahl der Threads für parallele geplante Aufgaben
+        scheduler.setPoolSize(5);
         scheduler.setThreadNamePrefix("scheduled-task-");
         scheduler.setErrorHandler(t -> {
-            // Fehlerbehandlung für geplante Aufgaben
             System.err.println("Error in scheduled task: " + t.getMessage());
             t.printStackTrace();
         });

--- a/backend/src/main/java/at/big5health/klimaatlas/CacheConfig.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/CacheConfig.java
@@ -5,8 +5,9 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import java.util.Arrays;
 
 @Configuration
@@ -18,9 +19,26 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         ConcurrentMapCacheManager manager = new ConcurrentMapCacheManager();
         manager.setAllowNullValues(false);
-        manager.setCacheNames(Arrays.asList("weatherCache"));
+
+        // Cache-Regionen definieren:
+        // - weatherCache: Für individuelle Wetterdatenabfragen
+        // - temperatureGrid: Für das Temperatur-Raster pro Bundesland
+        manager.setCacheNames(Arrays.asList("weatherCache", "temperatureGrid"));
+
         return manager;
     }
 
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // Anzahl der Threads für parallele geplante Aufgaben
+        scheduler.setThreadNamePrefix("scheduled-task-");
+        scheduler.setErrorHandler(t -> {
+            // Fehlerbehandlung für geplante Aufgaben
+            System.err.println("Error in scheduled task: " + t.getMessage());
+            t.printStackTrace();
+        });
+        return scheduler;
+    }
 
 }

--- a/backend/src/main/java/at/big5health/klimaatlas/KlimaatlasApplication.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/KlimaatlasApplication.java
@@ -3,9 +3,11 @@ package at.big5health.klimaatlas;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class KlimaatlasApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/at/big5health/klimaatlas/controllers/WeatherController.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/controllers/WeatherController.java
@@ -25,9 +25,8 @@ import java.util.List;
 @AllArgsConstructor
 public class WeatherController {
 
-    @Autowired
     private final WeatherService weatherService;
-    private GridCacheService gridCacheService;
+    private final GridCacheService gridCacheService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)

--- a/backend/src/main/java/at/big5health/klimaatlas/controllers/WeatherController.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/controllers/WeatherController.java
@@ -1,8 +1,10 @@
 package at.big5health.klimaatlas.controllers;
 
 import at.big5health.klimaatlas.dtos.WeatherReportDTO;
+import at.big5health.klimaatlas.services.GridCacheService;
 import at.big5health.klimaatlas.services.WeatherService;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.time.LocalDate;
-
+import java.util.List;
 
 
 @RestController
@@ -23,7 +25,9 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class WeatherController {
 
+    @Autowired
     private final WeatherService weatherService;
+    private GridCacheService gridCacheService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -36,4 +40,20 @@ public class WeatherController {
         WeatherReportDTO report = weatherService.getWeather(cityName, longitude, latitude, actualDate);
         return ResponseEntity.ok(report);
     }
+
+    @GetMapping("/temperature-grid")
+    public ResponseEntity<List<GridCacheService.GridTemperature>> getTemperatureGridPoints(
+            @RequestParam(required = false) String state) {
+
+        List<GridCacheService.GridTemperature> gridPoints;
+
+        if (state != null && !state.isEmpty()) {
+            gridPoints = gridCacheService.getTemperatureGridForState(state);
+        } else {
+            gridPoints = gridCacheService.getAllTemperatureGridPoints();
+        }
+
+        return ResponseEntity.ok(gridPoints);
+    }
+
 }

--- a/backend/src/main/java/at/big5health/klimaatlas/grid/GridTemperature.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/grid/GridTemperature.java
@@ -1,0 +1,14 @@
+package at.big5health.klimaatlas.grid;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GridTemperature {
+
+    private final double latitude;
+    private final double longitude;
+    private final double temperature;
+
+}

--- a/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
@@ -1,6 +1,11 @@
 package at.big5health.klimaatlas.grid;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 @Component
@@ -11,6 +16,8 @@ public class GridUtil {
     // Meters per degree longitude depends on latitude
     private static final double METERS_PER_DEGREE_LONGITUDE_AT_EQUATOR = 111319.488;
     private static final double CELL_SIZE_METERS = 1000.0; // 1km
+
+    private static final Logger logger = LoggerFactory.getLogger(GridUtil.class);
 
 
     public GridCellInfo getGridCellForCoordinates(double latitude, double longitude) {
@@ -71,4 +78,33 @@ public class GridUtil {
 
         return new GridCellInfo(cellId, bbox, targetLatitude, targetLongitude);
     }
+
+    public List<GridCellInfo> generateGrid(BoundingBox boundingBox, double gridResolution) {
+
+        List<GridCellInfo> gridCells = new ArrayList<>();
+
+        logger.info("Generating grid for BoundingBox: {} with resolution: {}",
+                boundingBox.toApiString(), gridResolution);
+
+        // Berechne die Anzahl der Schritte in jede Richtung
+        double minLat = boundingBox.getMinLat();
+        double maxLat = boundingBox.getMaxLat();
+        double minLon = boundingBox.getMinLon();
+        double maxLon = boundingBox.getMaxLon();
+
+        // Berechne Punkte im Gitter
+        for (double lat = minLat; lat <= maxLat; lat += gridResolution) {
+            for (double lon = minLon; lon <= maxLon; lon += gridResolution) {
+                // Erzeuge eine GridCellInfo für diesen Punkt
+                GridCellInfo cell = getGridCellForCoordinates(lat, lon);
+                gridCells.add(cell);
+
+            }
+        }
+
+        logger.info("Generated {} grid cells", gridCells.size());
+        return gridCells;
+
+    }
+
 }

--- a/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
@@ -15,7 +15,7 @@ public class GridUtil {
     private static final double METERS_PER_DEGREE_LONGITUDE_AT_EQUATOR = 111319.488;
     private static final double CELL_SIZE_METERS = 1000.0; // 1km
 
-    private static final Logger logger = LoggerFactory.getLogger(GridUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GridUtil.class);
 
 
     public GridCellInfo getGridCellForCoordinates(double latitude, double longitude) {
@@ -81,7 +81,7 @@ public class GridUtil {
 
         List<GridCellInfo> gridCells = new ArrayList<>();
 
-        logger.info("Generating grid for BoundingBox: {} with resolution: {}",
+        LOGGER.info("Generating grid for BoundingBox: {} with resolution: {}",
                 boundingBox.toApiString(), gridResolution);
 
         double minLat = boundingBox.getMinLat();
@@ -99,7 +99,7 @@ public class GridUtil {
             }
         }
 
-        logger.info("Generated {} grid cells", gridCells.size());
+        LOGGER.info("Generated {} grid cells", gridCells.size());
         return gridCells;
 
     }

--- a/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/grid/GridUtil.java
@@ -4,9 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 @Component
 public class GridUtil {
@@ -86,19 +84,18 @@ public class GridUtil {
         logger.info("Generating grid for BoundingBox: {} with resolution: {}",
                 boundingBox.toApiString(), gridResolution);
 
-        // Berechne die Anzahl der Schritte in jede Richtung
         double minLat = boundingBox.getMinLat();
         double maxLat = boundingBox.getMaxLat();
         double minLon = boundingBox.getMinLon();
         double maxLon = boundingBox.getMaxLon();
+        Set<String> seen = new HashSet<>();
 
-        // Berechne Punkte im Gitter
         for (double lat = minLat; lat <= maxLat; lat += gridResolution) {
             for (double lon = minLon; lon <= maxLon; lon += gridResolution) {
-                // Erzeuge eine GridCellInfo für diesen Punkt
                 GridCellInfo cell = getGridCellForCoordinates(lat, lon);
-                gridCells.add(cell);
-
+                if (seen.add(cell.getCellId())) {
+                    gridCells.add(cell);
+                }
             }
         }
 

--- a/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Executors;
 @Service
 public class GridCacheService {
 
-    private static final Logger logger = LoggerFactory.getLogger(GridCacheService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GridCacheService.class);
 
     public record GridTemperature(double latitude, double longitude, double temperature) {}
 
@@ -55,18 +55,18 @@ public class GridCacheService {
 
     @PostConstruct
     public void initializeGridCache() {
-        logger.info("Initializing temperature grid cache for all Austrian states");
+        LOGGER.info("Initializing temperature grid cache for all Austrian states");
 
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
         for (Map.Entry<String, BoundingBox> state : austrianStates.entrySet()) {
             CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
                 try {
-                    logger.info("Loading temperature grid for state: {}", state.getKey());
+                    LOGGER.info("Loading temperature grid for state: {}", state.getKey());
                     getTemperatureGridForState(state.getKey());
-                    logger.info("Successfully loaded temperature grid for state: {}", state.getKey());
+                    LOGGER.info("Successfully loaded temperature grid for state: {}", state.getKey());
                 } catch (Exception e) {
-                    logger.error("Failed to load temperature grid for state: {}", state.getKey(), e);
+                    LOGGER.error("Failed to load temperature grid for state: {}", state.getKey(), e);
                 }
             }, executorService);
 
@@ -74,13 +74,13 @@ public class GridCacheService {
         }
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-        logger.info("Temperature grid cache initialization completed");
+        LOGGER.info("Temperature grid cache initialization completed");
     }
 
     @Scheduled(cron = "0 0 10 * * ?")
     @CacheEvict(value = "temperatureGrid", allEntries = true)
     public void refreshCache() {
-        logger.info("Refreshing temperature grid cache");
+        LOGGER.info("Refreshing temperature grid cache");
         initializeGridCache();
     }
 
@@ -121,7 +121,7 @@ public class GridCacheService {
                             temperature));
                 }
             } catch (Exception e) {
-                logger.warn("Could not fetch temperature data for point {}, {}",
+                LOGGER.warn("Could not fetch temperature data for point {}, {}",
                         cell.getTargetLatitude(), cell.getTargetLongitude(), e);
             }
         }
@@ -138,7 +138,7 @@ public class GridCacheService {
             if (cached != null) {
                 allPoints.addAll(cached);
             } else {
-                logger.warn("No cached temperature grid for state: {}", state);
+                LOGGER.warn("No cached temperature grid for state: {}", state);
             }
         }
         return allPoints;

--- a/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
@@ -31,10 +31,10 @@ public class GridCacheService {
     public record GridTemperature(double latitude, double longitude, double temperature) {}
 
     @Autowired
-    private WeatherService weatherService;
+    protected WeatherService weatherService;
 
     @Autowired
-    private GridUtil gridUtil;
+    protected GridUtil gridUtil;
 
     @Autowired
     private CacheManager cacheManager;

--- a/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
@@ -1,0 +1,182 @@
+package at.big5health.klimaatlas.services;
+
+import at.big5health.klimaatlas.dtos.WeatherReportDTO;
+import at.big5health.klimaatlas.grid.BoundingBox;
+import at.big5health.klimaatlas.grid.GridCellInfo;
+import at.big5health.klimaatlas.grid.GridUtil;
+import at.big5health.klimaatlas.models.WeatherReport;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+public class GridCacheService {
+
+    private static final Logger logger = LoggerFactory.getLogger(GridCacheService.class);
+
+    @Autowired
+    private WeatherService weatherService;
+
+    @Autowired
+    private GridUtil gridUtil;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    // Definition der österreichischen Bundesländer mit deren Bounding Boxes
+    private final Map<String, BoundingBox> austrianStates = new HashMap<String, BoundingBox>() {{
+        put("Niederösterreich", new BoundingBox(47.4, 48.7, 14.4, 17.2));
+        put("Wien", new BoundingBox(48.1, 48.3, 16.2, 16.6));
+        put("Burgenland", new BoundingBox(46.7, 48.1, 16.0, 17.2));
+        put("Steiermark", new BoundingBox(46.6, 47.9, 13.6, 16.2));
+        put("Oberösterreich", new BoundingBox(47.4, 48.8, 12.7, 14.9));
+        put("Salzburg", new BoundingBox(46.8, 47.9, 12.5, 13.8));
+        put("Kärnten", new BoundingBox(46.4, 47.2, 12.6, 15.0));
+        put("Tirol", new BoundingBox(46.6, 47.8, 10.0, 13.0));
+        put("Vorarlberg", new BoundingBox(46.8, 47.6, 9.5, 10.3));
+    }};
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+    // Diese Methode wird beim Start der Anwendung ausgeführt
+    @PostConstruct
+    public void initializeGridCache() {
+        logger.info("Initializing temperature grid cache for all Austrian states");
+
+        // Parallel laden der Daten für alle Bundesländer
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (Map.Entry<String, BoundingBox> state : austrianStates.entrySet()) {
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                try {
+                    logger.info("Loading temperature grid for state: {}", state.getKey());
+                    getTemperatureGridForState(state.getKey());
+                    logger.info("Successfully loaded temperature grid for state: {}", state.getKey());
+                } catch (Exception e) {
+                    logger.error("Failed to load temperature grid for state: {}", state.getKey(), e);
+                }
+            }, executorService);
+
+            futures.add(future);
+        }
+
+        // Warten bis alle Daten geladen sind (optional)
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        logger.info("Temperature grid cache initialization completed");
+    }
+
+    // Diese Methode wird jeden Tag um 10:00 Uhr ausgeführt
+    @Scheduled(cron = "0 0 10 * * ?")
+    @CacheEvict(value = "temperatureGrid", allEntries = true)
+    public void refreshCache() {
+        logger.info("Refreshing temperature grid cache");
+        initializeGridCache();
+    }
+
+    @Cacheable(value = "temperatureGrid", key = "#stateName")
+    public List<GridTemperature> getTemperatureGridForState(String stateName) {
+        BoundingBox boundingBox = austrianStates.get(stateName);
+        if (boundingBox == null) {
+            throw new IllegalArgumentException("Unknown state: " + stateName);
+        }
+
+        // Berechne ein Raster von Punkten innerhalb der Bounding Box
+        // mit einer angemessenen Auflösung (z.B. alle 0.1 Grad)
+        double gridResolution = 0.1; // ca. 10km
+        List<GridCellInfo> gridCells = gridUtil.generateGrid(boundingBox, gridResolution);
+
+        List<GridTemperature> gridTemperatures = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+
+        for (GridCellInfo cell : gridCells) {
+            try {
+                // Verwende die getWeather-Methode statt getWeatherReport
+                double lat = cell.getTargetLatitude();
+                double lon = cell.getTargetLongitude();
+
+                // Angepasst an die vorhandene WeatherService API
+                WeatherReportDTO report = weatherService.getWeather(null, lon, lat, today);
+
+                // Extrahiere die Temperatur aus dem WeatherReportDTO
+                // Verwende den Mittelwert aus Min und Max, wenn verfügbar
+                Double temperature = null;
+                if (report.getMinTemp() != null && report.getMaxTemp() != null) {
+                    temperature = (report.getMinTemp() + report.getMaxTemp()) / 2.0;
+                } else if (report.getMaxTemp() != null) {
+                    temperature = report.getMaxTemp();
+                } else if (report.getMinTemp() != null) {
+                    temperature = report.getMinTemp();
+                }
+
+                if (temperature != null) {
+                    gridTemperatures.add(new GridTemperature(
+                            cell.getTargetLatitude(),
+                            cell.getTargetLongitude(),
+                            temperature));
+                }
+            } catch (Exception e) {
+                // Fehler protokollieren, aber weitermachen
+                logger.warn("Could not fetch temperature data for point {}, {}",
+                        cell.getTargetLatitude(), cell.getTargetLongitude(), e);
+            }
+        }
+
+        return gridTemperatures;
+    }
+
+    public List<GridTemperature> getAllTemperatureGridPoints() {
+        List<GridTemperature> allPoints = new ArrayList<>();
+
+        for (String state : austrianStates.keySet()) {
+            try {
+                List<GridTemperature> statePoints = getTemperatureGridForState(state);
+                allPoints.addAll(statePoints);
+            } catch (Exception e) {
+                logger.error("Error retrieving temperature grid for state: {}", state, e);
+            }
+        }
+
+        return allPoints;
+    }
+
+    // Innere Klasse zur Repräsentation eines Temperaturpunktes im Raster
+    public static class GridTemperature {
+        private final double latitude;
+        private final double longitude;
+        private final double temperature;
+
+        public GridTemperature(double latitude, double longitude, double temperature) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.temperature = temperature;
+        }
+
+        public double getLatitude() {
+            return latitude;
+        }
+
+        public double getLongitude() {
+            return longitude;
+        }
+
+        public double getTemperature() {
+            return temperature;
+        }
+    }
+
+}

--- a/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
+++ b/backend/src/main/java/at/big5health/klimaatlas/services/GridCacheService.java
@@ -14,7 +14,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,9 +2,10 @@ spring.application.name=klimaatlas
 
 # -- Caching Configuration --
 spring.cache.type=caffeine
-spring.cache.cache-names=dailyWeatherDataGrid
+spring.cache.cache-names=dailyWeatherDataGrid, weatherData, temperatureGrid
 spring.cache.caffeine.spec=maximumSize=100000,expireAfterWrite=25h
-
+klimaatlas.grid.resolution=0.1
+spring.task.scheduling.pool.size=5
 
 # -- External API Configuration --
 spartacus.api.baseUrl=https://dataset.api.hub.geosphere.at/v1/grid/historical/spartacus-v2-1d-1km

--- a/backend/src/test/java/at/big5health/klimaatlas/GridCacheServiceIntegrationTest.java
+++ b/backend/src/test/java/at/big5health/klimaatlas/GridCacheServiceIntegrationTest.java
@@ -1,0 +1,102 @@
+package at.big5health.klimaatlas;
+
+import at.big5health.klimaatlas.dtos.WeatherReportDTO;
+import at.big5health.klimaatlas.grid.BoundingBox;
+import at.big5health.klimaatlas.grid.GridCellInfo;
+import at.big5health.klimaatlas.grid.GridUtil;
+import at.big5health.klimaatlas.services.GridCacheService;
+import at.big5health.klimaatlas.services.WeatherService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class GridCacheServiceIntegrationTest {
+
+    @Autowired
+    private GridCacheService gridCacheService;
+
+    @MockitoBean
+    private WeatherService weatherService;
+
+
+    @Test
+    void testTemperatureGridForUnknownState_throwsException() {
+        // Then
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            gridCacheService.getTemperatureGridForState("Atlantis");
+        });
+    }
+
+    @Test
+    void testGenerateGrid_returnsNonEmptyGrid() {
+
+        BoundingBox bbox = new BoundingBox(48.0, 16.0, 48.3, 16.3);
+
+        double resolution = 0.01;
+
+        GridUtil gridUtil = new GridUtil();
+
+        List<GridCellInfo> gridCells = gridUtil.generateGrid(bbox, resolution);
+
+        gridCells.forEach(cell -> System.out.println(cell.getCellId()));
+
+        assertThat(gridCells.size()).isGreaterThanOrEqualTo(1);
+
+    }
+
+    @Test
+    void testWeatherServiceError_doesNotBreakGridCollection() {
+        // Mock WeatherService
+        WeatherService weatherService = mock(WeatherService.class);
+        GridUtil gridUtil = new GridUtil(); // Optional: auch mockbar, falls nötig
+
+        // Simuliere: erster Aufruf schlägt fehl, zweiter liefert gültige Daten
+        when(weatherService.getWeather(any(), anyDouble(), anyDouble(), any(LocalDate.class)))
+                .thenThrow(new RuntimeException("Fehler bei erster Zelle"))
+                .thenAnswer(invocation -> {
+                    WeatherReportDTO dto = new WeatherReportDTO();
+                    dto.setMinTemp(10.0);
+                    dto.setMaxTemp(20.0);
+                    return dto;
+                });
+
+        GridCacheService service = new GridCacheService() {{
+            this.weatherService = weatherService;
+            this.gridUtil = new GridUtil();
+        }};
+
+        Map<String, BoundingBox> testStates = new HashMap<>();
+        testStates.put("Wien", new BoundingBox(48.1, 48.2, 16.2, 16.3));
+
+        try {
+            Field field = GridCacheService.class.getDeclaredField("austrianStates");
+            field.setAccessible(true);
+            field.set(service, testStates);
+        } catch (Exception e) {
+            fail("Konnte austrianStates nicht setzen: " + e.getMessage());
+        }
+
+        // When
+        List<GridCacheService.GridTemperature> result = service.getTemperatureGridForState("Wien");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isGreaterThanOrEqualTo(1);
+        assertThat(result.get(0).temperature()).isEqualTo(15.0);
+    }
+
+
+}

--- a/backend/src/test/java/at/big5health/klimaatlas/WeatherControllerTest.java
+++ b/backend/src/test/java/at/big5health/klimaatlas/WeatherControllerTest.java
@@ -6,6 +6,7 @@ import at.big5health.klimaatlas.dtos.WeatherReportDTO;
 import at.big5health.klimaatlas.exceptions.ErrorMessages;
 import at.big5health.klimaatlas.exceptions.ExternalApiException;
 import at.big5health.klimaatlas.exceptions.WeatherDataNotFoundException;
+import at.big5health.klimaatlas.services.GridCacheService;
 import at.big5health.klimaatlas.services.WeatherService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,9 @@ class WeatherControllerTest {
 
     @MockitoBean // Create a mock bean for WeatherService in the application context
     private WeatherService weatherService;
+
+    @MockitoBean
+    private GridCacheService gridCacheService;
 
     @Autowired
     private ObjectMapper objectMapper; // For JSON assertions if needed


### PR DESCRIPTION
# Description
This PR reworks the caching mechanism of the GridCacheService to preload temperature grid data for all Austrian states during application startup. This change enables the frontend to display temperature pins distributed across Austria immediately when the atlas map loads, without requiring an initial user interaction. It improves responsiveness and provides a clear overview of temperature distribution from the start.

Additionally, the cache is refreshed automatically once per day at 10 a.m. to ensure up-to-date data without manual intervention.

## Key Components Included in This PR
+ Refactored GridCacheService to:
  + Load temperature grid data per state (e.g., "Wien", "Steiermark") at application startup.
  + Store this data in a per-state cache using Spring’s @Cacheable and @CacheEvict annotations.
+ Scheduled daily refresh of the cache at 10:00 a.m. via a cron job (@Scheduled), ensuring data stays fresh.
+ Improved error handling so that failures during weather data retrieval for individual grid cells are logged but do not break the entire process.
+ Helper methods to retrieve all cached temperature data across states (getAllTemperatureGridPoints()), which supports the frontend in rendering initial map overlays.

## Important Changes
+ Startup Behavior: Preloads grid-based temperature data per Austrian state using the predefined bounding boxes.
+ Caching Logic: Ensures cached entries are reused for repeated access to the same state's data.
+ Scheduling: Cache is cleared and rebuilt daily at 10:00 a.m. without requiring a service restart.
+ Frontend Support: Enables rendering of Austria-wide temperature pins immediately when the map view loads.
+ Robustness: Fault-tolerant fetching process ensures partial data availability even if some grid points fail due to external API issues.