### PR TITLE
feat: add e2e tests

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -17,6 +17,7 @@ policies:
       exclude:
         - '^Merge branch.*'
         - '^Merge pull request.*'
+        - '^Merge(.*)'
       conventional:
         types:
           - refactor

--- a/README.md
+++ b/README.md
@@ -69,7 +69,25 @@ project-root/
 │   ├── config/                        # Code quality tools (Checkstyle, PMD)
 │   ├── build.gradle                   # Gradle build file
 │   └── settings.gradle
-└── frontend/ (coming soon)
+├── frontend/
+│   ├── src/
+│   │   ├── app/
+│   │   │   ├── interfaces/              # TypeScript interfaces, types, enums (optionally `models`)
+│   │   │   ├── layout/                  # Application layout components (header, footer, nav)
+│   │   │   ├── services/                # Services for the apps
+│   │   │   ├── utils/                   # Utility functions, constants, formatters
+│   │   │   ├── app.component.ts
+│   │   │   ├── app.component.html
+│   │   │   ├── app.component.scss
+│   │   │   ├── app.component.spec.ts
+│   │   │   ├── app.config.ts
+│   │   │   ├── app.routes.ts
+│   │   ├── assets/                     # Static assets (images, icons, etc.)
+│   │   ├── index.html
+│   │   ├── main.ts
+│   │   └── styles.scss
+│   ├── e2e/                           # End-to-End Tests
+│   ├── test-results/                  # Test result outputs
 ```
 
 ---

--- a/frontend/e2e/admin-page.ts
+++ b/frontend/e2e/admin-page.ts
@@ -22,8 +22,8 @@ export class AdminPage {
     this.loginButton = page.locator('button[type="submit"]');
     this.wrongCredentialsMessage = page.locator('.wrong-credentials');
 
-    this.healthRiskTextArea = page.locator('textarea[placeholder="Default input"]');
-    this.saveButton = page.locator('button:has-text("Save")');
+    this.healthRiskTextArea = page.locator('textarea[placeholder="Health Risk text"]');
+    this.saveButton = page.locator('button:has-text("Save Risk")');
 
     this.modal = page.locator('.modal.show');
     this.modalText = page.locator('.modal-body p');
@@ -42,7 +42,7 @@ export class AdminPage {
 
   async expectRedirectToHealthDataWriter() {
     await this.page.waitForURL('**/healthdatawriter');
-    await expect(this.healthRiskTextArea).toBeVisible();
+    await expect(this.healthRiskTextArea).toBeVisible({ timeout: 5000 });
   }
 
   async writeHealthRiskText(text: string) {

--- a/frontend/e2e/admin-page.ts
+++ b/frontend/e2e/admin-page.ts
@@ -1,0 +1,67 @@
+import { expect, Page } from '@playwright/test';
+
+export class AdminPage {
+  readonly page: Page;
+
+  readonly usernameInput;
+  readonly passwordInput;
+  readonly loginButton;
+  readonly wrongCredentialsMessage;
+
+  readonly healthRiskTextArea;
+  readonly saveButton;
+  readonly modal;
+  readonly modalText;
+  readonly closeButton;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.usernameInput = page.locator('#username');
+    this.passwordInput = page.locator('#password');
+    this.loginButton = page.locator('button[type="submit"]');
+    this.wrongCredentialsMessage = page.locator('.wrong-credentials');
+
+    this.healthRiskTextArea = page.locator('textarea[placeholder="Default input"]');
+    this.saveButton = page.locator('button:has-text("Save")');
+
+    this.modal = page.locator('.modal.show');
+    this.modalText = page.locator('.modal-body p');
+    this.closeButton = page.locator('button:has-text("Close")');
+  }
+
+  async goto() {
+    await this.page.goto('/admin');
+  }
+
+  async login(username: string, password: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.loginButton.click();
+  }
+
+  async expectRedirectToHealthDataWriter() {
+    await this.page.waitForURL('**/healthdatawriter');
+    await expect(this.healthRiskTextArea).toBeVisible();
+  }
+
+  async writeHealthRiskText(text: string) {
+    await this.healthRiskTextArea.fill(text);
+    await this.saveButton.click();
+  }
+
+  async expectModalWithText(expected: string) {
+    await expect(this.modal).toBeVisible();
+    await expect(this.modalText).toHaveText(expected);
+  }
+
+  async closeModal() {
+    await this.closeButton.click();
+    await expect(this.modal).toHaveCount(0);
+  }
+
+  async expectWrongCredentialsMessage() {
+    await expect(this.wrongCredentialsMessage).toBeVisible();
+  }
+
+}

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '@playwright/test';
+import { AdminPage } from './admin-page';
+
+test.describe('Admin Login and Health Risk Editor', () => {
+  let admin: AdminPage;
+
+  test.beforeEach(async ({ page }) => {
+    admin = new AdminPage(page);
+    await admin.goto();
+  });
+
+  test('should login and add health risk text successfully', async () => {
+    await admin.login('admin', 'admin');
+    await admin.expectRedirectToHealthDataWriter();
+
+    const healthText = 'Extreme heat increases cardiovascular risks, especially in urban areas.';
+    await admin.writeHealthRiskText(healthText);
+
+    await admin.expectModalWithText('The text is successfully written and available on the main page.');
+    await admin.closeModal();
+  });
+
+  test('should show error on wrong credentials', async () => {
+    await admin.login('admin', 'wrong-password');
+    await admin.expectWrongCredentialsMessage();
+  });
+
+});

--- a/frontend/e2e/klimaatlas-page.ts
+++ b/frontend/e2e/klimaatlas-page.ts
@@ -5,12 +5,24 @@ export class KlimaatlasPage {
   readonly searchBar: Locator;
   readonly mapCanvas: Locator;
   readonly suggestions: Locator;
+  readonly lensToggleButton: Locator;
+  readonly mosquitoLensOption: Locator;
+  readonly temperatureLensOption: Locator;
+  readonly lensDropdown: Locator;
+  readonly mosquitoPins: Locator;
+  readonly temperaturePins: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.searchBar = page.locator('input[placeholder="Ort oder Postleitzahl..."]').first();
     this.mapCanvas = page.locator('div#map');
     this.suggestions = page.locator('ul.list-group > li.list-group-item');
+    this.lensToggleButton = page.locator('button.lens-icon');
+    this.lensDropdown = page.locator('ul.lens-dropdown');
+    this.mosquitoLensOption = this.lensDropdown.locator('li').nth(0);
+    this.temperatureLensOption = this.lensDropdown.locator('li').nth(1);
+    this.mosquitoPins = page.locator('img[alt="mosquito lens"]');
+    this.temperaturePins = page.locator('img[alt="temperature lens"]');
   }
 
   async goto() {
@@ -61,4 +73,30 @@ export class KlimaatlasPage {
       await this.page.mouse.up();
     }
   }
+
+  async openLensDropdown() {
+    await this.lensToggleButton.click();
+    await expect(this.lensDropdown).toHaveClass(/open/);
+  }
+
+  async selectMosquitoLens() {
+    await this.openLensDropdown();
+    await this.mosquitoLensOption.click();
+  }
+
+  async expectAtLeastOneMosquitoPin() {
+    const count = await this.mosquitoPins.count();
+     expect(count).toBeGreaterThan(0);
+  }
+
+  async selectTemperatureLens() {
+    await this.openLensDropdown();
+    await this.temperatureLensOption.click();
+  }
+
+  async expectAtLeastOneTemperaturePin() {
+    const count = await this.temperaturePins.count();
+    expect(count).toBeGreaterThan(0);
+  }
+
 }

--- a/frontend/e2e/klimaatlas.spec.ts
+++ b/frontend/e2e/klimaatlas.spec.ts
@@ -10,7 +10,7 @@ test.describe('Klimaatlas Main Flows', () => {
     await klimaatlas.goto();
   });
 
-  test('should load homepage and verify key elements', async ({ page }) => {
+  test('should load homepage and verify key elements', async () => {
     await klimaatlas.expectTitle();
     await klimaatlas.expectSearchBarVisible();
     await klimaatlas.expectMapVisible();
@@ -18,29 +18,36 @@ test.describe('Klimaatlas Main Flows', () => {
 
   test('should search by postal code and city, and interact with the map', async ({ page }) => {
     await klimaatlas.searchLocation('1010');
-    await page.waitForTimeout(2000);
     await klimaatlas.expectLabelVisible('Wien');
 
     await klimaatlas.searchLocation('Pinkafeld');
-    await page.waitForTimeout(2000);
     await klimaatlas.expectLabelVisible('Pinkafeld');
   });
 
-  test('should allow zooming and panning on the map', async ({ page }) => {
+  test('should allow zooming and panning on the map', async () => {
     await klimaatlas.expectMapVisible();
     await klimaatlas.simulateZoomAndPan();
-    await klimaatlas.expectMapVisible(); // Check no crash
+    await klimaatlas.expectMapVisible();
   });
 
   test('should show empty map if no data available for search', async ({ page }) => {
     await klimaatlas.searchLocation('9999');
-    await page.waitForTimeout(1000);
     await klimaatlas.expectNoMarkers();
   });
 
-  test('should show suggestions when typing in search bar', async ({ page }) => {
+  test('should show suggestions when typing in search bar', async () => {
     await klimaatlas.searchBar.fill('Wien');
     await klimaatlas.expectSuggestions();
   });
+
+  test('should switch to mosquito lens and display markers', async () => {
+      await klimaatlas.selectMosquitoLens();
+      await klimaatlas.expectAtLeastOneMosquitoPin();
+    });
+
+    test('should switch to temperature lens and display markers', async () => {
+      await klimaatlas.selectTemperatureLens();
+      await klimaatlas.expectAtLeastOneTemperaturePin();
+    });
 
 });


### PR DESCRIPTION
# Description
This pull request introduces comprehensive end-to-end (E2E) tests for the admin login flow and the health risk data editor using Playwright. These tests ensure that both successful and unsuccessful login attempts behave as expected, and that the health risk text can be submitted and confirmed via modal dialog.

## Key Components Included in This PR
+ e2e/admin.spec.ts: Main test suite covering:
  + Admin login with correct credentials
  + Error handling for incorrect credentials
  + Submission and verification of health risk text
+ e2e/admin-page.ts: Page Object Model encapsulating admin page interactions for login and health data submission
+ Test for modal dialog and redirect behavior after successful login

## Important Changes
+ Admin page is now expected to redirect to /healthdatawriter upon successful login
+ Textarea for health risk input is located and tested via placeholder attribute
+ Additional checks for error message (.wrong-credentials) on failed login attempts
+ Includes logic to close the confirmation modal after data submission